### PR TITLE
Feature/1/primitive types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 0.1.0 (2019-12-30)
+## 0.1.1 (unreleased)
 
-### Added
+* Support named primitive types (`usize`, `u*`, ..). ([#1])
+* Support arrays, slices, and tuples. ([#1])
+
+[#1]: https://github.com/azriel91/tynm/issues/1
+
+## 0.1.0 (2019-12-30)
 
 * `tynm::type_name` returns the simple type name.
 * `tynm::type_namem` returns the type name with a chosen number of most significant module segments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.1 (unreleased)
+## 0.1.1 (2020-01-02)
 
 * Support named primitive types (`usize`, `u*`, ..). ([#1])
 * Support arrays, slices, and tuples. ([#1])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tynm"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2018"
 description = "Returns type names in shorter form."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,12 @@ mod tests {
     }
 
     #[test]
+    fn type_name_slice() {
+        dbg!(crate::TypeName::from(std::any::type_name::<&[u32]>()));
+        assert_eq!(type_name::<&[u32]>(), "&[u32]");
+    }
+
+    #[test]
     fn type_name_unit_tuple() {
         assert_eq!(type_name::<()>(), "()");
         assert_eq!(type_name::<(Option<String>,)>(), "(Option<String>,)");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,3 +134,59 @@ pub fn type_namemn<T>(m: usize, n: usize) -> String {
     let type_name = TypeName::from(type_name_qualified);
     type_name.as_str_mn(m, n)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::type_name;
+
+    #[test]
+    fn type_name_primitives() {
+        assert_eq!(type_name::<usize>(), "usize");
+        assert_eq!(type_name::<u8>(), "u8");
+        assert_eq!(type_name::<u16>(), "u16");
+        assert_eq!(type_name::<u32>(), "u32");
+        assert_eq!(type_name::<u64>(), "u64");
+        assert_eq!(type_name::<u128>(), "u128");
+
+        assert_eq!(type_name::<isize>(), "isize");
+        assert_eq!(type_name::<i8>(), "i8");
+        assert_eq!(type_name::<i16>(), "i16");
+        assert_eq!(type_name::<i32>(), "i32");
+        assert_eq!(type_name::<i64>(), "i64");
+        assert_eq!(type_name::<i128>(), "i128");
+
+        assert_eq!(type_name::<f32>(), "f32");
+        assert_eq!(type_name::<f64>(), "f64");
+
+        assert_eq!(type_name::<bool>(), "bool");
+        assert_eq!(type_name::<char>(), "char");
+
+        assert_eq!(type_name::<HashMap<u32, String>>(), "HashMap<u32, String>");
+    }
+
+    #[test]
+    fn type_name_array() {
+        assert_eq!(type_name::<[u32; 3]>(), "[u32; 3]");
+        assert_eq!(type_name::<[Option<String>; 3]>(), "[Option<String>; 3]");
+    }
+
+    #[test]
+    fn type_name_unit_tuple() {
+        assert_eq!(type_name::<()>(), "()");
+        assert_eq!(type_name::<(Option<String>,)>(), "(Option<String>,)");
+        assert_eq!(
+            type_name::<(Option<String>, u32)>(),
+            "(Option<String>, u32)"
+        );
+    }
+
+    #[test]
+    fn type_name_reference() {
+        assert_eq!(type_name::<&str>(), "&str");
+
+        assert_eq!(type_name::<&Option<String>>(), "&Option<String>");
+        assert_eq!(type_name::<Option<&String>>(), "Option<&String>");
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,50 @@
 use nom::{
-    bytes::complete::{tag, take_while},
+    branch::alt,
+    bytes::complete::{tag, take_until, take_while},
     character::complete::char,
+    combinator::opt,
     multi::separated_list,
-    sequence::{delimited, tuple},
+    sequence::{delimited, pair, tuple},
     IResult,
 };
 
-use crate::types::TypeName;
+use crate::types::{
+    TypeName, TypeNameArray, TypeNameReference, TypeNameSlice, TypeNameStruct, TypeNameTuple,
+};
+
+/// List of known primitive types
+///
+/// Note: Arrays and slices are not included in this list as their type name depends on the type
+/// parameter (and length).
+#[rustfmt::skip]
+const PRIMITIVE_TYPES: &[&str] = &[
+    // From side bar on <https://doc.rust-lang.org/std/primitive.slice.html>
+    // "array", [T; n]
+    "bool",
+    "char",
+    "f32",
+    "f64",
+    // "fn", // TODO
+    "i128",
+    "i16",
+    "i32",
+    "i64",
+    "i8",
+    "isize",
+    // "never", !
+    // "pointer", *
+    // "reference", &
+    // "slice", [T]
+    "str",
+    // "tuple", (T, ..)
+    "u128",
+    "u16",
+    "u32",
+    "u64",
+    "u8",
+    // "unit", ()
+    "usize",
+];
 
 pub fn is_alphanumeric_underscore(c: char) -> bool {
     c == '_' || c.is_ascii_alphanumeric()
@@ -48,25 +86,142 @@ pub fn type_simple_name(input: &str) -> IResult<&str, &str> {
 }
 
 pub fn type_parameters(input: &str) -> IResult<&str, Vec<TypeName>> {
-    if input.starts_with('<') {
-        delimited(char('<'), separated_list(tag(", "), type_name), char('>'))(input)
-    } else {
-        Ok((input, Vec::new()))
-    }
+    opt(delimited(
+        char('<'),
+        separated_list(tag(", "), type_name),
+        char('>'),
+    ))(input)
+    .map(|(input, type_params)| (input, type_params.unwrap_or_else(Vec::new)))
 }
 
-/// Parses a type name.
-pub fn type_name(input: &str) -> IResult<&str, TypeName> {
+pub fn array_length(input: &str) -> IResult<&str, Option<&str>> {
+    pair(tag("; "), take_until("]"))(input)
+        .map(|(input, (_, len))| (input, Some(len)))
+        .or_else(|e| {
+            if let nom::Err::Error((input, _)) = e {
+                Ok((input, None))
+            } else {
+                Err(e)
+            }
+        })
+}
+
+pub fn array_or_slice_internal(input: &str) -> IResult<&str, TypeName> {
+    tuple((type_name, array_length))(input).map(|(input, (type_param, len))| {
+        let type_param = Box::new(type_param);
+        if let Some(len) = len {
+            (input, TypeName::Array(TypeNameArray { type_param, len }))
+        } else {
+            (input, TypeName::Slice(TypeNameSlice { type_param }))
+        }
+    })
+}
+
+pub fn array_or_slice(input: &str) -> IResult<&str, TypeName> {
+    delimited(char('['), array_or_slice_internal, char(']'))(input)
+}
+
+pub fn parse_reference(input: &str) -> IResult<&str, TypeName> {
+    tuple((char('&'), opt(tag("mut")), opt(char(' ')), type_name))(input).map(
+        |(input, (_, mut_str, _, type_param))| {
+            let type_param = Box::new(type_param);
+            (
+                input,
+                TypeName::Reference(TypeNameReference {
+                    mutable: mut_str.is_some(),
+                    type_param,
+                }),
+            )
+        },
+    )
+}
+
+pub fn parse_unit(input: &str) -> IResult<&str, TypeName> {
+    tag("()")(input).map(|(input, _)| (input, TypeName::Unit))
+}
+
+pub fn parse_tuple(input: &str) -> IResult<&str, TypeName> {
+    delimited(
+        char('('),
+        separated_list(tag(", "), type_name),
+        tuple((opt(char(',')), char(')'))),
+    )(input)
+    .map(|(input, type_params)| {
+        let type_name_tuple = TypeName::Tuple(TypeNameTuple { type_params });
+        (input, type_name_tuple)
+    })
+}
+
+pub fn parse_unit_or_tuple(input: &str) -> IResult<&str, TypeName> {
+    alt((parse_unit, parse_tuple))(input)
+}
+
+pub fn named_primitive_or_struct(input: &str) -> IResult<&str, TypeName> {
+    // Check for primitive types first, otherwise we cannot distinguish the `std::u32` module from
+    // `u32` (type).
+    //
+    // We shouldn't have to worry about `use crate::u32; u32::SomeType` as the type name input
+    // should be the fully qualified crate name as determined by Rust.
+    if let Some(prim_type) = PRIMITIVE_TYPES
+        .iter()
+        .find(|prim_type| input.starts_with(*prim_type))
+    {
+        let remainder = &input[prim_type.len()..];
+        let next_char = remainder.chars().next();
+        let mut is_primitive_type = false;
+        if next_char.is_none() {
+            is_primitive_type = true;
+        } else if let Some(c) = next_char {
+            is_primitive_type = !is_lowercase_alphanumeric_underscore(c);
+        }
+
+        if is_primitive_type {
+            // Treat this as a type.
+            return Ok((
+                remainder,
+                TypeName::Struct(TypeNameStruct {
+                    module_path: vec![],
+                    simple_name: prim_type,
+                    type_params: vec![],
+                }),
+            ));
+        }
+    }
+
+    // Parse this as a module name
     tuple((module_path, type_simple_name, type_parameters))(input).map(
         |(s, (module_path, simple_name, type_params))| {
             (
                 s,
-                TypeName {
+                TypeName::Struct(TypeNameStruct {
                     module_path,
                     simple_name,
                     type_params,
-                },
+                }),
             )
         },
     )
+}
+
+/// Parses a type name.
+pub fn type_name(input: &str) -> IResult<&str, TypeName> {
+    // Primitive types begin with lowercase letters, but we have to detect them at this level, as
+    // lower parsers (`module_name`, `type_simple_name`) cannot tell if `"std::"` preceeds the input
+    // it is given.
+    //
+    // In addition, types may begin with symbols, and we should detect them here and branch to the
+    // relevant parsing functions.
+    if let Some(first_char) = input.chars().next() {
+        match first_char {
+            '[' => array_or_slice(input),
+            '*' => todo!("pointer"),
+            '!' => nom::character::complete::char('!')(input)
+                .map(|(input, _)| (input, TypeName::Never)),
+            '&' => parse_reference(input),
+            '(' => parse_unit_or_tuple(input),
+            _ => named_primitive_or_struct(input),
+        }
+    } else {
+        Ok((input, TypeName::None))
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -223,7 +223,8 @@ impl<'s> TypeNameSlice<'s> {
     where
         W: Write,
     {
-        buffer.write_str("&[")?;
+        // Don't need to prepend with `"&"` because slices are always passed in as references.
+        buffer.write_str("[")?;
         self.type_param.write_str(buffer, m, n)?;
         buffer.write_str("]")
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,31 +4,20 @@ use crate::parser;
 
 /// Organizes type name string into distinct parts.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TypeName<'s> {
-    /// Module path of this type.
-    pub(crate) module_path: Vec<&'s str>,
-    /// Simple type name, excluding type parameters.
-    pub(crate) simple_name: &'s str,
-    /// Type parameters to this type.
-    pub(crate) type_params: Vec<TypeName<'s>>,
+pub enum TypeName<'s> {
+    None,
+    Array(TypeNameArray<'s>),
+    // Function(TypeNameFunction<'s>), // TODO
+    Never,
+    Pointer(TypeNamePointer<'s>),
+    Reference(TypeNameReference<'s>),
+    Slice(TypeNameSlice<'s>),
+    Struct(TypeNameStruct<'s>),
+    Tuple(TypeNameTuple<'s>),
+    Unit,
 }
 
 impl<'s> TypeName<'s> {
-    /// Returns the module path of the type.
-    pub fn module_path(&self) -> &[&'s str] {
-        &self.module_path
-    }
-
-    /// Returns the simple name of the type, excluding type parameters.
-    pub fn simple_name(&self) -> &'s str {
-        self.simple_name
-    }
-
-    /// Returns the type parameters to the type.
-    pub fn type_params(&self) -> &[TypeName<'s>] {
-        &self.type_params
-    }
-
     /// Returns the type name string without any module paths.
     ///
     /// This is equivalent to calling `TypeName::as_str_mn(0, 0);`
@@ -52,6 +41,219 @@ impl<'s> TypeName<'s> {
             .unwrap_or_else(|e| panic!("Failed to write `TypeName` as String. Error: `{}`.", e));
 
         buffer
+    }
+
+    /// Writes the type name string to the given buffer.
+    ///
+    /// If the left and right module segments overlap, the overlapping segments will only be printed
+    /// once.
+    ///
+    /// # Parameters
+    ///
+    /// * `buffer`: Buffer to write to.
+    /// * `m`: Number of module segments to include, beginning from the left (most significant).
+    /// * `n`: Number of module segments to include, beginning from the right (least significant).
+    pub fn write_str<W>(&self, buffer: &mut W, m: usize, n: usize) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        match self {
+            Self::None => Ok(()),
+            Self::Array(type_name_array) => type_name_array.write_str(buffer, m, n),
+            Self::Never => buffer.write_str("!"),
+            Self::Pointer(type_name_pointer) => type_name_pointer.write_str(buffer, m, n),
+            Self::Reference(type_name_reference) => type_name_reference.write_str(buffer, m, n),
+            Self::Slice(type_name_slice) => type_name_slice.write_str(buffer, m, n),
+            Self::Struct(type_name_struct) => type_name_struct.write_str(buffer, m, n),
+            Self::Tuple(type_name_tuple) => type_name_tuple.write_str(buffer, m, n),
+            Self::Unit => buffer.write_str("()"),
+        }
+    }
+}
+
+/// Type name of an array.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeNameArray<'s> {
+    /// Type of each array element.
+    pub(crate) type_param: Box<TypeName<'s>>,
+    /// Array length.
+    pub(crate) len: &'s str,
+}
+
+impl<'s> TypeNameArray<'s> {
+    /// Returns the type parameter of this type.
+    pub fn type_param(&self) -> &Box<TypeName<'s>> {
+        &self.type_param
+    }
+
+    /// Returns the type parameter of this type.
+    pub fn len(&self) -> &str {
+        self.len
+    }
+
+    /// Writes the type name string to the given buffer.
+    ///
+    /// If the left and right module segments overlap, the overlapping segments will only be printed
+    /// once.
+    ///
+    /// # Parameters
+    ///
+    /// * `buffer`: Buffer to write to.
+    /// * `m`: Number of module segments to include, beginning from the left (most significant).
+    /// * `n`: Number of module segments to include, beginning from the right (least significant).
+    pub fn write_str<W>(&self, buffer: &mut W, m: usize, n: usize) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        buffer.write_str("[")?;
+        self.type_param.write_str(buffer, m, n)?;
+        buffer.write_str("; ")?;
+        buffer.write_str(self.len)?;
+        buffer.write_str("]")
+    }
+}
+
+/// Type name of a pointer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeNamePointer<'s> {
+    /// Type of pointer.
+    pub(crate) const_or_mut: &'s str,
+    /// Type pointed to.
+    pub(crate) type_param: Box<TypeName<'s>>,
+}
+
+impl<'s> TypeNamePointer<'s> {
+    /// Returns the `"const"` or `"mut"` str.
+    pub fn const_or_mut(&self) -> &str {
+        self.const_or_mut
+    }
+
+    /// Returns the type parameter of this type.
+    pub fn type_param(&self) -> &Box<TypeName<'s>> {
+        &self.type_param
+    }
+
+    /// Writes the type name string to the given buffer.
+    ///
+    /// If the left and right module segments overlap, the overlapping segments will only be printed
+    /// once.
+    ///
+    /// # Parameters
+    ///
+    /// * `buffer`: Buffer to write to.
+    /// * `m`: Number of module segments to include, beginning from the left (most significant).
+    /// * `n`: Number of module segments to include, beginning from the right (least significant).
+    pub fn write_str<W>(&self, buffer: &mut W, m: usize, n: usize) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        buffer.write_str("* ")?;
+        buffer.write_str(self.const_or_mut)?;
+        buffer.write_str(" ")?;
+        self.type_param.write_str(buffer, m, n)
+    }
+}
+
+/// Type name of a reference.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeNameReference<'s> {
+    /// Type of reference.
+    pub(crate) mutable: bool,
+    /// Type referenced.
+    pub(crate) type_param: Box<TypeName<'s>>,
+}
+
+impl<'s> TypeNameReference<'s> {
+    /// Returns whether the reference is mutable.
+    pub fn mutable(&self) -> bool {
+        self.mutable
+    }
+
+    /// Returns the type parameter of this type.
+    pub fn type_param(&self) -> &Box<TypeName<'s>> {
+        &self.type_param
+    }
+
+    /// Writes the type name string to the given buffer.
+    ///
+    /// If the left and right module segments overlap, the overlapping segments will only be printed
+    /// once.
+    ///
+    /// # Parameters
+    ///
+    /// * `buffer`: Buffer to write to.
+    /// * `m`: Number of module segments to include, beginning from the left (most significant).
+    /// * `n`: Number of module segments to include, beginning from the right (least significant).
+    pub fn write_str<W>(&self, buffer: &mut W, m: usize, n: usize) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        buffer.write_str("&")?;
+        if self.mutable {
+            buffer.write_str("mut ")?;
+        }
+        self.type_param.write_str(buffer, m, n)
+    }
+}
+
+/// Type name of a slice.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeNameSlice<'s> {
+    /// Type of each slice element.
+    pub(crate) type_param: Box<TypeName<'s>>,
+}
+
+impl<'s> TypeNameSlice<'s> {
+    /// Returns the type parameter of this type.
+    pub fn type_param(&self) -> &Box<TypeName<'s>> {
+        &self.type_param
+    }
+
+    /// Writes the type name string to the given buffer.
+    ///
+    /// If the left and right module segments overlap, the overlapping segments will only be printed
+    /// once.
+    ///
+    /// # Parameters
+    ///
+    /// * `buffer`: Buffer to write to.
+    /// * `m`: Number of module segments to include, beginning from the left (most significant).
+    /// * `n`: Number of module segments to include, beginning from the right (least significant).
+    pub fn write_str<W>(&self, buffer: &mut W, m: usize, n: usize) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        buffer.write_str("&[")?;
+        self.type_param.write_str(buffer, m, n)?;
+        buffer.write_str("]")
+    }
+}
+
+/// Type name of a struct.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeNameStruct<'s> {
+    /// Module path of this type.
+    pub(crate) module_path: Vec<&'s str>,
+    /// Simple type name, excluding type parameters.
+    pub(crate) simple_name: &'s str,
+    /// Type parameters to this type.
+    pub(crate) type_params: Vec<TypeName<'s>>,
+}
+
+impl<'s> TypeNameStruct<'s> {
+    /// Returns the module path of the type.
+    pub fn module_path(&self) -> &[&'s str] {
+        &self.module_path
+    }
+
+    /// Returns the simple name of the type, excluding type parameters.
+    pub fn simple_name(&self) -> &'s str {
+        self.simple_name
+    }
+
+    /// Returns the type parameters of this type.
+    pub fn type_params(&self) -> &[TypeName<'s>] {
+        &self.type_params
     }
 
     /// Writes the type name string to the given buffer.
@@ -165,6 +367,57 @@ impl<'s> TypeName<'s> {
     }
 }
 
+/// Type name of a tuple.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeNameTuple<'s> {
+    /// Type parameters to this type.
+    pub(crate) type_params: Vec<TypeName<'s>>,
+}
+
+impl<'s> TypeNameTuple<'s> {
+    /// Returns the type parameters of this type.
+    pub fn type_params(&self) -> &[TypeName<'s>] {
+        &self.type_params
+    }
+
+    /// Writes the type name string to the given buffer.
+    ///
+    /// If the left and right module segments overlap, the overlapping segments will only be printed
+    /// once.
+    ///
+    /// # Parameters
+    ///
+    /// * `buffer`: Buffer to write to.
+    /// * `m`: Number of module segments to include, beginning from the left (most significant).
+    /// * `n`: Number of module segments to include, beginning from the right (least significant).
+    pub fn write_str<W>(&self, buffer: &mut W, m: usize, n: usize) -> Result<(), Error>
+    where
+        W: Write,
+    {
+        if self.type_params.len() > 0 {
+            buffer.write_str("(")?;
+
+            if let Some((first, rest)) = self.type_params.split_first() {
+                first.write_str(buffer, m, n)?;
+
+                if self.type_params.len() == 1 {
+                    buffer.write_str(",")?; // Always write `,` after first type.
+                } else {
+                    rest.iter().try_for_each(|type_param| {
+                        buffer
+                            .write_str(", ")
+                            .and_then(|_| type_param.write_str(buffer, m, n))
+                    })?;
+                }
+            }
+
+            buffer.write_str(")")?;
+        }
+
+        Ok(())
+    }
+}
+
 impl<'s> From<&'s str> for TypeName<'s> {
     fn from(std_type_name: &'s str) -> Self {
         parser::type_name(std_type_name)
@@ -182,24 +435,24 @@ impl<'s> From<&'s str> for TypeName<'s> {
 mod tests {
     use pretty_assertions::assert_eq;
 
-    use super::TypeName;
+    use super::{TypeName, TypeNameStruct};
 
     macro_rules! type_name_simple {
         () => {{
-            TypeName {
+            TypeName::Struct(TypeNameStruct {
                 module_path: vec!["tynm", "types", "tests"],
                 simple_name: "Simple",
                 type_params: Vec::new(),
-            }
+            })
         }};
     }
     macro_rules! type_name_type_param_single {
         () => {{
-            TypeName {
+            TypeName::Struct(TypeNameStruct {
                 module_path: vec!["tynm", "types", "tests"],
                 simple_name: "TypeParamSingle",
                 type_params: vec![type_name_simple!()],
-            }
+            })
         }};
     }
 
@@ -223,11 +476,11 @@ mod tests {
 
     #[test]
     fn parse_nested_type_parameterized_struct() {
-        let expected = TypeName {
+        let expected = TypeName::Struct(TypeNameStruct {
             module_path: vec!["tynm", "types", "tests"],
             simple_name: "TypeParamSingle",
             type_params: vec![type_name_type_param_single!()],
-        };
+        });
 
         let actual = TypeName::from(std::any::type_name::<
             TypeParamSingle<TypeParamSingle<Simple>>,
@@ -238,11 +491,11 @@ mod tests {
 
     #[test]
     fn parse_multi_type_parameterized_struct() {
-        let expected = TypeName {
+        let expected = TypeName::Struct(TypeNameStruct {
             module_path: vec!["tynm", "types", "tests"],
             simple_name: "TypeParamDouble",
             type_params: vec![type_name_simple!(), type_name_simple!()],
-        };
+        });
 
         let actual = TypeName::from(std::any::type_name::<TypeParamDouble<Simple, Simple>>());
 
@@ -251,14 +504,14 @@ mod tests {
 
     #[test]
     fn parse_nested_multi_type_parameterized_struct() {
-        let expected = TypeName {
+        let expected = TypeName::Struct(TypeNameStruct {
             module_path: vec!["tynm", "types", "tests"],
             simple_name: "TypeParamDouble",
             type_params: vec![
                 type_name_type_param_single!(),
                 type_name_type_param_single!(),
             ],
-        };
+        });
 
         let actual = TypeName::from(std::any::type_name::<
             TypeParamDouble<TypeParamSingle<Simple>, TypeParamSingle<Simple>>,


### PR DESCRIPTION
Fixes #1.

Notably this doesn't add support for pointers / `fn`s. This can be done as necessary, either by switching to `syn`, or extending the `nom` implementation.