### PR TITLE
Add a `Display` impl for `TypeName`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 //! [`std::any::type_name`]: https://doc.rust-lang.org/std/any/fn.type_name.html
 
 pub use crate::types::TypeName;
+pub use crate::types::TypeNameDisplay;
 
 mod parser;
 mod types;
@@ -139,7 +140,9 @@ pub fn type_namemn<T>(m: usize, n: usize) -> String {
 mod tests {
     use std::collections::HashMap;
 
+    use super::TypeName;
     use super::type_name;
+    use super::type_namemn;
 
     #[test]
     fn type_name_primitives() {
@@ -194,5 +197,31 @@ mod tests {
 
         assert_eq!(type_name::<&Option<String>>(), "&Option<String>");
         assert_eq!(type_name::<Option<&String>>(), "Option<&String>");
+    }
+
+    #[test]
+    fn type_name_display() {
+        use std::sync::atomic::AtomicI8;
+
+        type T<'a> = Box<HashMap<Option<String>, &'a AtomicI8>>;
+
+        let tn: TypeName = TypeName::new::<T>();
+
+        let display = tn.as_display();
+        let string = format!("{}", display);
+        assert_eq!(type_name::<T>(), string);
+    }
+
+    #[test]
+    fn type_name_display_mn() {
+        use std::sync::atomic::AtomicI8;
+
+        type T<'a> = Box<HashMap<Option<String>, &'a AtomicI8>>;
+
+        let tn: TypeName = TypeName::new::<T>();
+
+        let display = tn.as_display_mn(1,0);
+        let string = format!("{}", display);
+        assert_eq!(type_namemn::<T>(1,0), string);
     }
 }


### PR DESCRIPTION
One way to use this crate is to print out those type name, e.g. with `println!`. However, first building a string is less elegant than having a `fmt::Display` implementation that avoids the `String` allocation.

Therefore, this PR adds a new struct `TypeNameDisplay` which wraps a `TypeName` reference and a `m` and `n` value. It implements `Display` by using `TypeName::write_str` in conjunction with its `m` and `n`. This PR also adds a `new` method to `TypeName`, which is a short-cut to get an instance for a stringified `T`, as construction from `&str` is already provided via `From`. Also some test-cases are included.