### PR TITLE
Maintenance/support rust 1 38 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: rust
 sudo: required
 
 rust:
+  - '1.38.0'
   - stable
   - nightly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Use `unimplemented!` macro instead of `todo!` to support Rust 1.38.0. ([#5])
+
+[#5]: https://github.com/azriel91/tynm/pulls/5
+
 ## 0.1.2 (2020-01-10)
 
 * `TypeName::new::<T>()` returns a `TypeName` instance for `T` without constructing the String. ([#3])

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -214,7 +214,7 @@ pub fn type_name(input: &str) -> IResult<&str, TypeName> {
     if let Some(first_char) = input.chars().next() {
         match first_char {
             '[' => array_or_slice(input),
-            '*' => todo!("pointer"),
+            '*' => unimplemented!("`tynm` is not implemented for pointer types."),
             '!' => nom::character::complete::char('!')(input)
                 .map(|(input, _)| (input, TypeName::Never)),
             '&' => parse_reference(input),


### PR DESCRIPTION
Swap `todo!` macro for `unimplemented!` so that this compiles on Rust 1.38.