### PR TITLE
Fix integer overflow with `usize::MAX` for m,n.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub fn type_namemn<T>(m: usize, n: usize) -> String {
 mod tests {
     use std::collections::HashMap;
 
-    use super::{type_name, type_namemn, TypeName};
+    use super::{type_name, type_namem, type_namemn, TypeName};
 
     #[test]
     fn type_name_primitives() {
@@ -220,5 +220,11 @@ mod tests {
         let display = tn.as_display_mn(1, 0);
         let string = format!("{}", display);
         assert_eq!(type_namemn::<T>(1, 0), string);
+    }
+    
+    #[test]
+    fn type_name_usize_mn() {
+    	assert_eq!(type_namem::<usize>(std::usize::MAX), "::usize");
+    	assert_eq!(type_namemn::<usize>(std::usize::MAX, std::usize::MAX), "::usize");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -381,7 +381,7 @@ impl<'s> TypeNameStruct<'s> {
     where
         W: Write,
     {
-        let module_segment_count = m + n;
+        let module_segment_count = m.saturating_add(n);
 
         if module_segment_count >= self.module_path.len() {
             // Print full module path


### PR DESCRIPTION
In the current version `type_namemn(std::usize::MAX, std::usize::MAX)` panics with an integer overflow. This pull request fixes it by using `usize::saturating_add` for the `module_segment_count` (i.e. `m + n`). Also includes a test case with the above example.