### PR TITLE
Support creating TypeName from `dyn Trait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6 (2020-10-13)
+
+* Support creating `TypeName` from `dyn Trait`.
+
 ## 0.1.5 (2020-10-13)
 
 * Support parsing `dyn Trait`. ([#9], [#10])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tynm"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2018"
 description = "Returns type names in shorter form."

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,7 +53,7 @@ impl<'s> TypeName<'s> {
     /// Constructs a new TypeName with the name of `T`.
     ///
     /// This is equivalent to calling `std::any::type_name::<T>().into()`
-    pub fn new<T>() -> Self {
+    pub fn new<T: ?Sized>() -> Self {
         std::any::type_name::<T>().into()
     }
 


### PR DESCRIPTION
Missing from 0.1.5